### PR TITLE
Enhance README with bilingual tasting profile and cspell config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Neither white nor black can color us… we are BRUN.
 
-## 味の判断基準
+## Tasting Profile
 
-| 項目 | 内容 |
+| Attribute / 属性 | Notes / 説明 |
 | ---- | --- |
-| Sweetness: 甘み | 全体に感じる甘み |
-| Bitterness: 苦み | コーヒー的な苦み。深煎り感 |
-| Acidity: 酸味 | フルーティーな酸味。浅煎り感 |
-| Body: ボディ | 飲み物としての重量感や飲み応え |
-| Texture: 質感 | 口当たり。フォームミルクのきめ細かさやとろみ感 |
-| Aroma: 香り | 香りがどれくらい印象に残るか |
+| Sweetness / 甘み | Perceived sweetness across the palate. / 全体に感じる甘み |
+| Bitterness / 苦み | Coffee-like bitterness and depth from roasting. / コーヒー的な苦み。深煎り感 |
+| Acidity / 酸味 | Fruity acidity and light roast character. / フルーティーな酸味。浅煎り感 |
+| Body / ボディ | Weight and fullness of the beverage. / 飲み物としての重量感や飲み応え |
+| Texture / 質感 | Mouthfeel including milk foam fineness and viscosity. / 口当たり。フォームミルクのきめ細かさやとろみ感 |
+| Aroma / 香り | How memorable and impactful the aroma is. / 香りがどれくらい印象に残るか |
 
 ## Tasting
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Neither white nor black can color us… we are BRUN.
 
 | 項目 | 内容 |
 | ---- | --- |
-| 甘み(Sweetness) | 全体に感じる甘み |
-| 苦み(Bitterness) | コーヒー的な苦み。深煎り感 |
-| 酸味(Acidity) | フルーティーな酸味。浅煎り感 |
-| ボディ(Body) | 飲み物としての重量感や飲み応え |
-| 質感(Texture) | 口当たり。フォームミルクのきめ細かさやとろみ感 |
-| 香り(Aroma) | 香りがどれくらい印象に残るか |
+| Sweetness: 甘み | 全体に感じる甘み |
+| Bitterness: 苦み | コーヒー的な苦み。深煎り感 |
+| Acidity: 酸味 | フルーティーな酸味。浅煎り感 |
+| Body: ボディ | 飲み物としての重量感や飲み応え |
+| Texture: 質感 | 口当たり。フォームミルクのきめ細かさやとろみ感 |
+| Aroma: 香り | 香りがどれくらい印象に残るか |
 
 ## Tasting
 

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2",
+    "ignorePaths": [],
+    "dictionaryDefinitions": [],
+    "dictionaries": [],
+    "words": [
+        "brun",
+        "goyokiki",
+        "kotaoue"
+    ],
+    "ignoreWords": [],
+    "import": []
+}


### PR DESCRIPTION
This pull request updates the documentation to provide a clearer and more accessible tasting profile section and adds a configuration file for spell checking. The most important changes are grouped below:

Documentation improvements:
* The tasting profile table in `README.md` was rewritten in bilingual format (English and Japanese), with expanded descriptions for each attribute to make the tasting criteria clearer and more accessible.

Tooling and configuration:
* Added a new `cspell.json` configuration file to set up spell checking for the project, including custom words relevant to the repository.